### PR TITLE
Add privacy policy page and link from landing page

### DIFF
--- a/landing_site/index.html
+++ b/landing_site/index.html
@@ -164,5 +164,8 @@
       </div>
     </div>
   </div>
+  <footer style="text-align:center; padding:20px 0;">
+    <a href="privacy.html" style="color:var(--muted); text-decoration:none;">Privacy Policy</a>
+  </footer>
 </body>
 </html>

--- a/landing_site/privacy.html
+++ b/landing_site/privacy.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Privacy Policy - Echoes of the Crystal Realm</title>
+  <style>
+    :root{
+      --bg:#1b1c30;
+      --card:#2d2d45;
+      --text:#e6e6f6;
+      --muted:#b2b6d3;
+    }
+    body{
+      margin:0;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial, sans-serif;
+      color:var(--text);
+      background:var(--bg);
+    }
+    .container{
+      max-width:800px;
+      margin:0 auto;
+      padding:40px 20px;
+      line-height:1.6;
+    }
+    a{ color:var(--muted); }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Privacy Policy for Echo in the Crystal Realm</h1>
+    <h2>Information We Collect:</h2>
+    <ul>
+      <li>Account Information: Email address when you sign up or log in.</li>
+      <li>Chat Content: Messages in the App, stored to provide chat functionality.</li>
+      <li>Crash &amp; Diagnostics: Device information, crash logs, and app usage data (collected automatically).</li>
+      <li>Purchase Data: Subscription and purchase history (via Apple In-App Purchase and RevenueCat).</li>
+    </ul>
+    <h2>How We Use Information:</h2>
+    <ul>
+      <li>Authenticate and manage user accounts.</li>
+      <li>Provide and maintain chat functionality.</li>
+      <li>Process subscriptions and purchases through Apple and RevenueCat.</li>
+      <li>Diagnose crashes, improve stability, and enhance performance.</li>
+      <li>Respond to support requests.</li>
+    </ul>
+    <h2>Data Sharing:</h2>
+    <p>We do not sell your personal data. We share data only with trusted providers that enable core app features:</p>
+    <ul>
+      <li>Apple (App Store, In-App Purchase): Payment processing.</li>
+      <li>RevenueCat: Subscription management and purchase verification.</li>
+      <li>Firebase (Google LLC): Authentication, analytics, and crash reporting.</li>
+    </ul>
+    <p>Each provider processes data in accordance with their own privacy policies.</p>
+    <h2>Your Choices:</h2>
+    <ul>
+      <li>You can request account deletion by using the in-app “Delete Account” option (if available).</li>
+      <li>You may opt out of analytics (where applicable) in device settings (iOS Settings → Privacy &amp; Security → Analytics &amp; Improvements).</li>
+    </ul>
+    <h2>Data Retention:</h2>
+    <p>We retain personal data only as long as necessary to provide the App or comply with legal obligations. Chat logs and crash data may be retained for diagnostics and improvement.</p>
+    <h2>Changes:</h2>
+    <p>We may update this Privacy Policy from time to time. Updates will be posted here with a new “Last updated” date.</p>
+    <p><a href="index.html">Back to Home</a></p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone privacy policy page outlining data collection, usage, sharing, user choices, retention, and changes
- link to privacy policy from landing page footer

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b384e9b4ec832ead09bdbdcac2c202